### PR TITLE
store query string in session to correctly re-create form

### DIFF
--- a/cmsplugin_form_handler/cms_plugins.py
+++ b/cmsplugin_form_handler/cms_plugins.py
@@ -57,7 +57,12 @@ class FormPluginBase(CMSPluginBase):
             data = None
 
             if hasattr(request, 'session'):
-                data = QueryDict(request.session.get(get_session_key(instance.pk)))
+                data = request.session.get(get_session_key(instance.pk))
+                try:
+                    data = QueryDict(data)
+                except TypeError:
+                    # the data must have already been saved as a dict. just use the dict until a string is saved
+                    pass
             elif request.GET.get('cmsplugin_form_plugin_id'):
                 # Sessions aren't available, see if we fell-back to GET params
                 plugin_id = request.GET.get('cmsplugin_form_plugin_id')

--- a/cmsplugin_form_handler/cms_plugins.py
+++ b/cmsplugin_form_handler/cms_plugins.py
@@ -2,6 +2,8 @@
 
 from __future__ import unicode_literals
 
+from django.http import QueryDict
+
 from cms.plugin_base import CMSPluginBase
 
 from . import get_session_key
@@ -55,7 +57,7 @@ class FormPluginBase(CMSPluginBase):
             data = None
 
             if hasattr(request, 'session'):
-                data = request.session.get(get_session_key(instance.pk))
+                data = QueryDict(request.session.get(get_session_key(instance.pk)))
             elif request.GET.get('cmsplugin_form_plugin_id'):
                 # Sessions aren't available, see if we fell-back to GET params
                 plugin_id = request.GET.get('cmsplugin_form_plugin_id')

--- a/cmsplugin_form_handler/views.py
+++ b/cmsplugin_form_handler/views.py
@@ -106,7 +106,7 @@ class ProcessFormView(FormView):
         data = form.data.copy()
         if getattr(self.request, 'session'):
             session_key = get_session_key(plugin_id)
-            self.request.session[session_key] = data
+            self.request.session[session_key] = data.urlencode()
         else:
             # Fallback to GET params...
             # Don't need this on the URL


### PR DESCRIPTION
Right now, a dictionary is stored in the session for the form data. But query strings can use the same key multiple times. So storing a dictionary will lose data.

Instead, it should store the query string representation, and then convert it back to a QueryDict. That is what this fix does.