### PR TITLE
Add get_form_kwargs to allow extra parameters to be passed to the form

### DIFF
--- a/cmsplugin_form_handler/cms_plugins.py
+++ b/cmsplugin_form_handler/cms_plugins.py
@@ -30,8 +30,8 @@ class FormPluginBase(CMSPluginBase):
     def get_form_kwargs(self, request):
         """
         Returns any additional kwargs to add to the form.
-        
-        Default implementation is to return and empty dict.
+
+        Default implementation is to return an empty dict.
         """
         return {}
 

--- a/cmsplugin_form_handler/cms_plugins.py
+++ b/cmsplugin_form_handler/cms_plugins.py
@@ -27,6 +27,14 @@ class FormPluginBase(CMSPluginBase):
         """
         return self.form_class
 
+    def get_form_kwargs(self, request):
+        """
+        Returns any additional kwargs to add to the form.
+        
+        Default implementation is to return and empty dict.
+        """
+        return {}
+
     def get_success_url(self, request, instance):
         """
         Returns the redirect URL for successful form submissions.
@@ -63,7 +71,7 @@ class FormPluginBase(CMSPluginBase):
                     data = request.GET.copy()
 
             if data:
-                context['cmsplugin_form'] = form_class(source_url, data=data)
+                context['cmsplugin_form'] = form_class(source_url, data=data, **self.get_form_kwargs(request))
             else:
-                context['cmsplugin_form'] = form_class(source_url)
+                context['cmsplugin_form'] = form_class(source_url, **self.get_form_kwargs(request))
         return context

--- a/cmsplugin_form_handler/views.py
+++ b/cmsplugin_form_handler/views.py
@@ -56,6 +56,7 @@ class ProcessFormView(FormView):
     def get_form_kwargs(self):
         kwargs = super(ProcessFormView, self).get_form_kwargs()
         kwargs['source_url'] = self.source_url
+        kwargs.update(self.plugin.get_form_kwargs(self.request))
         return kwargs
 
     def get_success_url(self):

--- a/cmsplugin_form_handler/views.py
+++ b/cmsplugin_form_handler/views.py
@@ -54,9 +54,10 @@ class ProcessFormView(FormView):
             'Source form plugin does not define `get_form_class()`.')
 
     def get_form_kwargs(self):
+        _, plugin = self.plugin
         kwargs = super(ProcessFormView, self).get_form_kwargs()
         kwargs['source_url'] = self.source_url
-        kwargs.update(self.plugin.get_form_kwargs(self.request))
+        kwargs.update(plugin.get_form_kwargs(self.request))
         return kwargs
 
     def get_success_url(self):


### PR DESCRIPTION
Useful if you want to pass the request object or the current user to the plugin form. Follows standard Django implementation like the rest of the functions.